### PR TITLE
Use available xcodebuild to accept license

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
   become: true
 
 - name: Accept license (optional)
-  shell: xcodebuild -license accept
+  shell: "/Applications/Xcode-{{ xcode_version }}.app/Contents/Developer/usr/bin/xcodebuild -license accept"
   become: true
 
 - name: Remove installer


### PR DESCRIPTION
Issue:
```
fatal: [hostname]: FAILED! => {
  "changed": true,
  "cmd": "xcodebuild -license accept",
  "delta": "0:00:00.013938",
  "end": "2020-12-08 19:36:47.142665",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2020-12-08 19:36:47.128727",
  "stderr": "xcode-select: note: no developer tools were found at '/Applications/Xcode.app', requesting install. Choose an option in the dialog to download the command line developer tools.",
  "stderr_lines": [
    "xcode-select: note: no developer tools were found at '/Applications/Xcode.app', requesting install. Choose an option in the dialog to download the command line developer tools."
  ],
  "stdout": "",
  "stdout_lines": []
}
```